### PR TITLE
PostGIS is Postgres

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -88,7 +88,7 @@ module Delayed
 
         def self.reserve_with_scope_using_optimized_sql(ready_scope, worker, now)
           case connection.adapter_name
-          when "PostgreSQL"
+          when "PostgreSQL", "PostGIS"
             # Custom SQL required for PostgreSQL because postgres does not support UPDATE...LIMIT
             # This locks the single record 'FOR UPDATE' in the subquery
             # http://www.postgresql.org/docs/9.0/static/sql-select.html#SQL-FOR-UPDATE-SHARE


### PR DESCRIPTION
PostGIS has a different adapter name but needs PostgreSQL locking. 

Without this, users with PostGIS will have the same job picked up by multiple workers.
